### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It allows for a workflow similar to that in web development with *Typescript*, w
 
 ## How to Use
 
-1. ```luarocks install tl cyan```
+1. `luarocks install tl && luarocks install cyan` 
 2. Write your code in *Teal* (using `.tl` files)
 3. Add your modules into the Squishy file (used to generate the final amalgamation)
 4. Use `npm run build` to create your `main.lua` output


### PR DESCRIPTION
Luarocks fails to install multiple packages at the same time.

```bash
❯ luarocks install tl cyan

Error: No results matching query were found for Lua 5.4.
To check if it is available for other Lua versions, use --check-lua-versions.
```